### PR TITLE
fix: changed system prompt related to history

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,13 @@ def generate_response_stream(user_id, chat_id, user_input):
     history_prompt = ""
     if len(my_history) >  0: # 기존 대화 내역이 있음. 
 
-        history_prompt = "이 질문에 답변하는데, 다음의 기존 대화 내역과 연관이 있으면, 다음의 기존 대화 내역을 참고해줘. 기존 대화 내역: \n```"
+        #history_prompt = "이 질문에 답변하는데, 다음의 기존 대화 내역과 연관이 있으면, 다음의 기존 대화 내역을 참고해줘. 기존 대화 내역: \n```"
+
+        history_prompt = """
+                        When answering this question, refer to the existing conversation history below if needed.\n",
+                        "If the conversation history is not relevant or helpful for this question, proceed without referencing it.\n",
+                        "existing conversation history: ```
+                        """
         for h in my_history:
             history_prompt +=  h['role']+":"+h['text']+"\n"
         history_prompt += '```'


### PR DESCRIPTION
### 📟 연결된 이슈

.

### 👷 작업한 내용
####문제
기존 대화 내역이 필요 없는 경우에도 자꾸 기존 대화 내역 부르는 문제 
#### 수정 사항
프롬프트 변경 전
```#history_prompt = "이 질문에 답변하는데, 다음의 기존 대화 내역과 연관이 있으면, 다음의 기존 대화 내역을 참고해줘. 기존 대화 내역: \n```"
```
프롬프트 변경 후 
```
history_prompt = """
                When answering this question, refer to the existing conversation history below if needed.\n",
                "If the conversation history is not relevant or helpful for this question, proceed without referencing it.\n",
                "existing conversation history: ```
                        """`
```


### 📸 스크린샷
관련 문제
<img width="612" alt="스크린샷 2024-09-26 오후 4 48 25" src="https://github.com/user-attachments/assets/8567caf3-d99d-4428-8bbe-ba0c4af9e930">

